### PR TITLE
fix: support HLS playback on cycanime

### DIFF
--- a/src/adapter/cycanime/play.ts
+++ b/src/adapter/cycanime/play.ts
@@ -1,4 +1,5 @@
 import { KPlayer } from '../../player'
+import { execInUnsafeWindow } from '../../utils/execInUnsafeWindow'
 import { queryDom } from '../../utils/queryDom'
 import { wait } from '../../utils/wait'
 import { defineIframePlayer } from '../common/defineIframePlayer'
@@ -40,6 +41,11 @@ export async function parser() {
 
   await wait(() => !!video.currentSrc)
   let url = video.currentSrc
+
+  if (url.startsWith('blob:')) {
+    url = await execInUnsafeWindow(() => window.decrypt(window.config.url))
+  }
+
   video.src = ''
   const player = new KPlayer('#mui-player', {
     eventToParentWindow: true,


### PR DESCRIPTION
修复次元城部分 HLS 视频加载失败（如《少女终末旅行》），遇到无法复用的 blob URL 时改为获取实际播放 URL。

<img width="1978" height="1083" alt="PixPin_2026-07-31_13-02-39" src="https://github.com/user-attachments/assets/bc148a58-5980-4cf7-abe0-8b5eade3ef10" />
<img width="1976" height="1092" alt="PixPin_2026-07-31_13-01-35" src="https://github.com/user-attachments/assets/b119973e-42ec-4dd4-bc4e-a91944bc47e3" />
